### PR TITLE
feat(docker): 添加 Docker 支持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22-alpine3.19
+
+ENV DISPLAY=:0
+ENV SCREEN_WIDTH=1280
+ENV SCREEN_HEIGHT=720
+ENV VNC_PASSWORD=password
+ENV LANGUAGE=zh-CN
+ENV STARTUP_URL=https://docs.ocsjs.com/
+ENV TZ=Asia/Shanghai
+
+# 安装依赖
+RUN apk add --no-cache wget unzip tigervnc chromium chromium-lang font-noto-cjk tzdata
+
+# 下载 Tampermonkey
+RUN ["wget", "-O", "/tampermonkey.crx", "https://clients2.google.com/service/update2/crx?response=redirect&prodversion=125.0.6422.112&acceptformat=crx2,crx3&x=id%3Ddhdgffkkebhmkfjojejmpbldmpobfkfo%26uc"]
+RUN unzip /tampermonkey.crx -d /tampermonkey || true
+RUN rm /tampermonkey.crx
+
+RUN mkdir /root/.vnc
+
+WORKDIR /docker
+
+COPY docker/package.json /docker/package.json
+RUN npm install
+
+COPY docker/entrypoint.sh /docker/
+COPY docker/init.mjs /docker/
+COPY docker/preferences.json /data/Default/Preferences
+
+ENTRYPOINT [ "/docker/entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+rm /tmp/.X*-lock
+echo $VNC_PASSWORD | vncpasswd -f > /root/.vnc/passwd
+chmod 600 /root/.vnc/passwd
+Xvnc $DISPLAY -PasswordFile /root/.vnc/passwd -geometry "${SCREEN_WIDTH}x${SCREEN_HEIGHT}" &
+
+chromium \
+    --user-data-dir=/data \
+    --no-sandbox --disable-dev-shm-usage --no-first-run \
+    --disable-extensions-except=/tampermonkey --load-extension=/tampermonkey \
+    --remote-debugging-port=19222 \
+    --window-position=0,0 "--window-size=${SCREEN_WIDTH},${SCREEN_HEIGHT}" &
+sleep 2s
+node init.mjs

--- a/docker/init.mjs
+++ b/docker/init.mjs
@@ -1,0 +1,27 @@
+import { chromium } from 'playwright';
+
+const log = (message) => console.log(`[OCS Docker] [${new Date().toISOString()}] ${message}`);
+
+log('Connecting to Chromium...');
+const browser = await chromium.connectOverCDP('http://127.0.0.1:19222');
+const context = browser.contexts()[0];
+const page = context.pages()[0];
+
+context.on('page', async (page) => {
+	const url = page.url();
+	log(`New page: ${url}`);
+	if (url.includes('tampermonkey.net/index.php')) {
+		log('Closing Tampermonkey homepage...');
+		await page.close();
+	} else if (url.match(/^chrome-extension:\/\/.*ask\.html.*$/)) {
+		await page.click('input.button.install');
+	}
+});
+
+log('Installing OCS script...');
+const tempPage = await context.newPage();
+await tempPage.goto('https://www.tampermonkey.net/script_installation.php#url=https://cdn.ocsjs.com/ocs.user.js');
+await tempPage.close();
+
+log('Navigating to startup URL...');
+await page.goto(process.env.STARTUP_URL);

--- a/docker/package.json
+++ b/docker/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "playwright": "^1.44.1"
+  }
+}

--- a/docker/preferences.json
+++ b/docker/preferences.json
@@ -1,0 +1,7 @@
+{
+  "extensions": {
+    "ui": {
+      "developer_mode": true
+    }
+  }
+}


### PR DESCRIPTION
## 概述

目前使用 OCS 基本只能挂在电脑上，一直占着也挺烦的，于是研究了一会尝试加了简单的 Docker 支持，就可以扔服务器上不用管了（

镜像基于 Alpine，可以通过 VNC 连接至容器内的 Chromium 来随时监控脚本的运行状态。

## 实现

大致流程如下：

1. 使用 `Xvnc` 启动一个虚拟 X Server + VNC Server
2. Chromium 通过 `--load-extension` 加载 Tampermonkey，渲染在虚拟 X Server 上
3. 使用 Playwright 脚本控制 Tampermonkey 及 OCS 的初始化

启动 URL、VNC 相关环境都可以配置