### PR TITLE
fix(script): 修复智慧树课程无法关闭答题弹窗的BUG

### DIFF
--- a/packages/scripts/src/projects/zhs.ts
+++ b/packages/scripts/src/projects/zhs.ts
@@ -153,7 +153,7 @@ class StudyVideoH5 implements ZHSProcessor {
 			}
 			await $.sleep(1000);
 			// 关闭弹窗
-			const close_btn_selector = '#playTopic-dialog .close-btn';
+			const close_btn_selector = '#playTopic-dialog .el-dialog__headerbtn';
 			if (this.remotePage) {
 				await this.remotePage.click(close_btn_selector);
 			} else {


### PR DESCRIPTION
针对issue#226
fix(script): 修复智慧树课程无法关闭答题弹窗的BUG
bug原因疑似智慧树修改了页面代码导致原有过滤器失效
根据新的页面更新了过滤器以确保可以关闭答题弹窗