### PR TITLE
chore: 添加 .DS_Store 文件到 .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ package-lock.json
 
 **/*.zip
 
+# DesktopServices Store
+
+.DS_Store
+
 # tsc
 
 lib/


### PR DESCRIPTION
- .DS_Store 是 macOS 系统在每个文件夹中创建的隐藏文件，用于存储文件夹的显示属性
- 将 .DS_Store 添加到 .gitignore 可以防止这些无关的文件被提交到版本库