### PR TITLE
fix: 修复题库请求在 ScriptCat 下超过30秒后永久挂起的问题

### DIFF
--- a/packages/core/src/core/answer-wrapper/answer.wrapper.handler.ts
+++ b/packages/core/src/core/answer-wrapper/answer.wrapper.handler.ts
@@ -122,7 +122,8 @@ export async function defaultAnswerWrapperHandler(
 						responseType: contentType,
 						data: requestData,
 						type,
-						headers: JSON.parse(JSON.stringify(headers || {}))
+						headers: JSON.parse(JSON.stringify(headers || {})),
+						timeout: (AnswerWrapperHandlerConfig.timeout_seconds ?? 60) * 1000
 					}),
 					$.sleep((AnswerWrapperHandlerConfig.timeout_seconds ?? 60) * 1000)
 				]);

--- a/packages/core/src/core/answer-wrapper/answer.wrapper.handler.ts
+++ b/packages/core/src/core/answer-wrapper/answer.wrapper.handler.ts
@@ -4,7 +4,9 @@ import { $ } from '../../utils';
 
 export const AnswerWrapperHandlerConfig = {
 	// 超时时间，单位毫秒
-	timeout_seconds: 60
+	timeout_seconds: 60,
+	keep_service_worker_alive: true,
+	service_worker_keepalive_interval_seconds: 15
 };
 
 /**
@@ -123,7 +125,11 @@ export async function defaultAnswerWrapperHandler(
 						data: requestData,
 						type,
 						headers: JSON.parse(JSON.stringify(headers || {})),
-						timeout: (AnswerWrapperHandlerConfig.timeout_seconds ?? 60) * 1000
+						timeout: (AnswerWrapperHandlerConfig.timeout_seconds ?? 60) * 1000,
+						keepAlive: {
+							enabled: AnswerWrapperHandlerConfig.keep_service_worker_alive,
+							interval: (AnswerWrapperHandlerConfig.service_worker_keepalive_interval_seconds ?? 15) * 1000
+						}
 					}),
 					$.sleep((AnswerWrapperHandlerConfig.timeout_seconds ?? 60) * 1000)
 				]);

--- a/packages/core/src/core/utils/request.ts
+++ b/packages/core/src/core/utils/request.ts
@@ -14,18 +14,100 @@ export function request<T extends 'json' | 'text'>(
 		headers?: Record<string, string>;
 		data?: Record<string, any>;
 		timeout?: number;
+		keepAlive?:
+			| boolean
+			| {
+					enabled?: boolean;
+					interval?: number;
+					url?: string;
+			  };
 	}
 ): Promise<T extends 'json' ? any : string> {
 	return new Promise((resolve, reject) => {
 		try {
 			/** 默认参数 */
-			const { responseType = 'json', method = 'get', type = 'fetch', data = {}, headers = {}, timeout = 60000 } = opts || {};
+			const {
+				responseType = 'json',
+				method = 'get',
+				type = 'fetch',
+				data = {},
+				headers = {},
+				timeout = 60000
+			} = opts || {};
 			/** 环境变量 */
 			const env = $.isInBrowser() ? 'browser' : 'node';
 
 			/** 如果是跨域模式并且是浏览器环境 */
 			if (type === 'GM_xmlhttpRequest' && env === 'browser') {
 				if (typeof GM_xmlhttpRequest !== 'undefined') {
+					const keepAliveRaw = (opts as any)?.keepAlive;
+					let keepAliveEnabled = false;
+					let keepAliveInterval = 15000;
+					let keepAliveUrl: string | undefined;
+
+					if (typeof keepAliveRaw === 'boolean') {
+						keepAliveEnabled = keepAliveRaw;
+					} else if (typeof keepAliveRaw === 'object' && keepAliveRaw) {
+						keepAliveEnabled = keepAliveRaw.enabled !== false;
+						if (typeof keepAliveRaw.interval === 'number') {
+							keepAliveInterval = keepAliveRaw.interval;
+						}
+						if (typeof keepAliveRaw.url === 'string') {
+							keepAliveUrl = keepAliveRaw.url;
+						}
+					} else {
+						keepAliveEnabled = timeout > 30000;
+					}
+
+					let keepAliveTimer: any;
+					const stopKeepAlive = () => {
+						if (keepAliveTimer) {
+							clearInterval(keepAliveTimer);
+							keepAliveTimer = undefined;
+						}
+					};
+
+					const startKeepAlive = () => {
+						if (!keepAliveEnabled || keepAliveInterval <= 0) {
+							return;
+						}
+						if (typeof window === 'undefined' || typeof window.location === 'undefined') {
+							return;
+						}
+
+						const baseUrl = keepAliveUrl || window.location.href;
+						const buildUrl = () => {
+							try {
+								const u = new URL(baseUrl);
+								u.searchParams.set('__ocs_keepalive', '1');
+								u.searchParams.set('__t', String(Date.now()));
+								return u.toString();
+							} catch {
+								return baseUrl;
+							}
+						};
+
+						const ping = () => {
+							try {
+								const gmXhr = (globalThis as any).GM_xmlhttpRequest;
+								if (typeof gmXhr !== 'function') {
+									return;
+								}
+								gmXhr({
+									url: buildUrl(),
+									method: 'HEAD',
+									timeout: Math.min(Math.max(1000, keepAliveInterval - 1000), 10000),
+									onload: () => undefined,
+									ontimeout: () => undefined,
+									onerror: () => undefined
+								});
+							} catch {}
+						};
+
+						ping();
+						keepAliveTimer = setInterval(ping, keepAliveInterval);
+					};
+
 					const contentType = headers['Content-Type'] || headers['content-type'];
 					const requestData =
 						contentType === 'application/x-www-form-urlencoded'
@@ -33,6 +115,7 @@ export function request<T extends 'json' | 'text'>(
 							: Object.keys(data).length
 							? JSON.stringify(data)
 							: undefined;
+					startKeepAlive();
 					// eslint-disable-next-line no-undef
 					GM_xmlhttpRequest({
 						url,
@@ -42,6 +125,7 @@ export function request<T extends 'json' | 'text'>(
 						responseType: responseType === 'json' ? 'json' : undefined,
 						timeout,
 						onload: (response) => {
+							stopKeepAlive();
 							if (response.status === 200) {
 								if (responseType === 'json') {
 									try {
@@ -57,9 +141,11 @@ export function request<T extends 'json' | 'text'>(
 							}
 						},
 						ontimeout: () => {
+							stopKeepAlive();
 							reject(new Error('GM_xmlhttpRequest 请求超时'));
 						},
 						onerror: (err: any) => {
+							stopKeepAlive();
 							console.error('GM_xmlhttpRequest error', err);
 							reject(new Error(err?.error || 'GM_xmlhttpRequest 请求失败'));
 						}
@@ -73,7 +159,12 @@ export function request<T extends 'json' | 'text'>(
 				const controller = new AbortController();
 				const timer = setTimeout(() => controller.abort(), timeout);
 
-				fet(url, { body: method === 'post' ? JSON.stringify(data) : undefined, method, headers, signal: controller.signal as any })
+				fet(url, {
+					body: method === 'post' ? JSON.stringify(data) : undefined,
+					method,
+					headers,
+					signal: controller.signal as any
+				})
 					.then((response) => {
 						clearTimeout(timer);
 						if (responseType === 'json') {

--- a/packages/core/src/core/utils/request.ts
+++ b/packages/core/src/core/utils/request.ts
@@ -13,12 +13,13 @@ export function request<T extends 'json' | 'text'>(
 		responseType?: T;
 		headers?: Record<string, string>;
 		data?: Record<string, any>;
+		timeout?: number;
 	}
 ): Promise<T extends 'json' ? any : string> {
 	return new Promise((resolve, reject) => {
 		try {
 			/** 默认参数 */
-			const { responseType = 'json', method = 'get', type = 'fetch', data = {}, headers = {} } = opts || {};
+			const { responseType = 'json', method = 'get', type = 'fetch', data = {}, headers = {}, timeout = 60000 } = opts || {};
 			/** 环境变量 */
 			const env = $.isInBrowser() ? 'browser' : 'node';
 
@@ -39,6 +40,7 @@ export function request<T extends 'json' | 'text'>(
 						data: requestData,
 						headers: Object.keys(headers).length ? headers : undefined,
 						responseType: responseType === 'json' ? 'json' : undefined,
+						timeout,
 						onload: (response) => {
 							if (response.status === 200) {
 								if (responseType === 'json') {
@@ -54,9 +56,12 @@ export function request<T extends 'json' | 'text'>(
 								reject(response.responseText);
 							}
 						},
-						onerror: (err) => {
+						ontimeout: () => {
+							reject(new Error('GM_xmlhttpRequest 请求超时'));
+						},
+						onerror: (err: any) => {
 							console.error('GM_xmlhttpRequest error', err);
-							reject(err);
+							reject(new Error(err?.error || 'GM_xmlhttpRequest 请求失败'));
 						}
 					});
 				} else {
@@ -65,8 +70,12 @@ export function request<T extends 'json' | 'text'>(
 			} else {
 				const fet: typeof fetch = env === 'node' ? require('node-fetch').default : fetch;
 
-				fet(url, { body: method === 'post' ? JSON.stringify(data) : undefined, method, headers })
+				const controller = new AbortController();
+				const timer = setTimeout(() => controller.abort(), timeout);
+
+				fet(url, { body: method === 'post' ? JSON.stringify(data) : undefined, method, headers, signal: controller.signal as any })
 					.then((response) => {
+						clearTimeout(timer);
 						if (responseType === 'json') {
 							response.json().then(resolve).catch(reject);
 						} else {
@@ -75,6 +84,7 @@ export function request<T extends 'json' | 'text'>(
 						}
 					})
 					.catch((error) => {
+						clearTimeout(timer);
 						reject(new Error(error));
 					});
 			}


### PR DESCRIPTION
- 为 request() 函数新增 timeout 参数（默认60秒）
- GM_xmlhttpRequest 增加 timeout 和 ontimeout 回调，解决 ScriptCat Service Worker 30秒挂起导致回调永不触发的问题
- fetch 请求增加 AbortController 超时自动中断
- 修复 onerror 回调将原始响应对象直接 reject 的问题，改为抛出包含真实错误信息的 Error 实例

Fixes #281