### PR TITLE
fix: 修复智慧职教题目图片链接被丢弃问题

### DIFF
--- a/packages/scripts/src/projects/icve.ts
+++ b/packages/scripts/src/projects/icve.ts
@@ -8,6 +8,7 @@ import {
 	QuestionTypes
 } from '@ocsjs/core';
 import { $gm, cors, $message, $$el, $modal, $el, Project, Script, $ui, h } from 'easy-us';
+import { optimizationElementWithImage } from '../utils/work';
 import { playbackRate, restudy, volume } from '../utils/configs';
 import { CommonWorkOptions, playMedia } from '../utils';
 import { CommonProject } from './common';
@@ -950,24 +951,12 @@ function aiWork({ answererWrappers, period, thread, answerSeparators, answerMatc
 
 	console.log({ answererWrappers, period, thread });
 
-	/**
-	 * 将元素中的 <img> 替换为其 src 链接，避免 innerText 丢失图片信息
-	 */
-	const replaceImgWithSrc = (el: HTMLElement) => {
-		const clone = el.cloneNode(true) as HTMLElement;
-		clone.querySelectorAll<HTMLImageElement>('img').forEach((img) => {
-			const textNode = document.createTextNode(img.src);
-			img.replaceWith(textNode);
-		});
-		return clone.innerText.trim();
-	};
-
 	const titleTransform = (titles: (HTMLElement | undefined)[]) => {
 		return titles
 			.filter((t) => t?.innerText)
 			.map((t) => {
 				if (t) {
-					return replaceImgWithSrc(t);
+					return optimizationElementWithImage(t, true).innerText.trim();
 				}
 				return '';
 			})
@@ -1002,7 +991,7 @@ function aiWork({ answererWrappers, period, thread, answerSeparators, answerMatc
 	const worker = new OCSWorker({
 		root: '.content-item',
 		elements: {
-			title: '.questions-content [class*=title-content]',
+			title: '.single-title-content, .questions-content [class*=title-content]',
 			options: 'label[class*=group-item],.ivu-input-wrapper input'
 		},
 		thread: thread ?? 1,
@@ -1017,7 +1006,7 @@ function aiWork({ answererWrappers, period, thread, answerSeparators, answerMatc
 					return defaultAnswerWrapperHandler(answererWrappers, {
 						type: getType(ctx.elements.options) || 'unknown',
 						title,
-						options: ctx.elements.options.map((o) => replaceImgWithSrc(o)).join('\n')
+						options: ctx.elements.options.map((o) => optimizationElementWithImage(o, true).innerText).join('\n')
 					});
 				});
 			} else {
@@ -1052,6 +1041,8 @@ function aiWork({ answererWrappers, period, thread, answerSeparators, answerMatc
 		},
 		onElementSearched(elements, root) {
 			console.log('elements', elements);
+			// 对选项元素进行图片优化，使默认 resolver 的 innerText 匹配也能获取到图片链接
+			elements.options?.forEach((option) => optimizationElementWithImage(option));
 		},
 
 		/**

--- a/packages/scripts/src/projects/icve.ts
+++ b/packages/scripts/src/projects/icve.ts
@@ -950,12 +950,24 @@ function aiWork({ answererWrappers, period, thread, answerSeparators, answerMatc
 
 	console.log({ answererWrappers, period, thread });
 
+	/**
+	 * 将元素中的 <img> 替换为其 src 链接，避免 innerText 丢失图片信息
+	 */
+	const replaceImgWithSrc = (el: HTMLElement) => {
+		const clone = el.cloneNode(true) as HTMLElement;
+		clone.querySelectorAll<HTMLImageElement>('img').forEach((img) => {
+			const textNode = document.createTextNode(img.src);
+			img.replaceWith(textNode);
+		});
+		return clone.innerText.trim();
+	};
+
 	const titleTransform = (titles: (HTMLElement | undefined)[]) => {
 		return titles
 			.filter((t) => t?.innerText)
 			.map((t) => {
 				if (t) {
-					return t.innerText.trim();
+					return replaceImgWithSrc(t);
 				}
 				return '';
 			})
@@ -1005,7 +1017,7 @@ function aiWork({ answererWrappers, period, thread, answerSeparators, answerMatc
 					return defaultAnswerWrapperHandler(answererWrappers, {
 						type: getType(ctx.elements.options) || 'unknown',
 						title,
-						options: ctx.elements.options.map((o) => o.innerText).join('\n')
+						options: ctx.elements.options.map((o) => replaceImgWithSrc(o)).join('\n')
 					});
 				});
 			} else {

--- a/packages/scripts/src/projects/icve.ts
+++ b/packages/scripts/src/projects/icve.ts
@@ -953,10 +953,13 @@ function aiWork({ answererWrappers, period, thread, answerSeparators, answerMatc
 
 	const titleTransform = (titles: (HTMLElement | undefined)[]) => {
 		return titles
-			.filter((t) => t?.innerText)
+			.filter((t) => t?.innerText || t?.querySelector('img'))
 			.map((t) => {
 				if (t) {
-					return optimizationElementWithImage(t, true).innerText.trim();
+					const el = optimizationElementWithImage(t, true);
+					// 使用 textContent 而非 innerText，因为 innerText 受 CSS 影响，
+					// fontSize: 0px 的隐藏 span 中的图片 URL 不会被 innerText 获取
+					return (el.textContent || '').replace(/\s+/g, ' ').trim() || '';
 				}
 				return '';
 			})

--- a/packages/scripts/src/projects/icve.ts
+++ b/packages/scripts/src/projects/icve.ts
@@ -994,7 +994,7 @@ function aiWork({ answererWrappers, period, thread, answerSeparators, answerMatc
 	const worker = new OCSWorker({
 		root: '.content-item',
 		elements: {
-			title: '.single-title-content, .questions-content [class*=title-content]',
+			title: '.questions-content [class*=title-content]',
 			options: 'label[class*=group-item],.ivu-input-wrapper input'
 		},
 		thread: thread ?? 1,


### PR DESCRIPTION
修复了智慧职教，题目以及选项中带有图片无法识别问题，使用optimizationElementWithImage，并防止纯图片.filter((t) => t?.innerText为 ''，而直接被丢弃，无法识别到链接 #288 