### PR TITLE
[codex] add YukeTang exam answer support

### DIFF
--- a/packages/scripts/src/projects/yuketang.exam.ts
+++ b/packages/scripts/src/projects/yuketang.exam.ts
@@ -1,0 +1,166 @@
+import { $, defaultAnswerWrapperHandler, OCSWorker, WorkResult } from '@ocsjs/core';
+import { $message } from 'easy-us';
+import { CommonWorkOptions } from '../utils';
+import { optimizationElementWithImage, simplifyWorkResult } from '../utils/work';
+import { BackgroundProject } from './background';
+import { CommonProject } from './common';
+
+function normalizeText(text: string) {
+	return text.replace(/\s+/g, ' ').trim();
+}
+
+function getQuestionTitle(titles: (HTMLElement | undefined)[]) {
+	return titles
+		.filter(Boolean)
+		.map((title) => normalizeText(optimizationElementWithImage(title as HTMLElement, true).innerText))
+		.filter(Boolean)
+		.join(',');
+}
+
+function getQuestionOptions(options: HTMLElement[]) {
+	return options
+		.map((option) => normalizeText(optimizationElementWithImage(option, true).innerText))
+		.filter(Boolean)
+		.join('\n');
+}
+
+function inferQuestionType(root: HTMLElement, options: HTMLElement[]): 'single' | 'multiple' | 'judgement' | 'completion' | undefined {
+	const typeText = normalizeText(root.querySelector('.item-type')?.textContent || '');
+
+	if (typeText.includes('单选')) {
+		return 'single';
+	}
+	if (typeText.includes('多选')) {
+		return 'multiple';
+	}
+	if (typeText.includes('判断')) {
+		return 'judgement';
+	}
+	if (/(填空|简答|主观)/.test(typeText)) {
+		return 'completion';
+	}
+
+	const radioCount = options.filter((option) => option.querySelector('[type="radio"]')).length;
+	const checkboxCount = options.filter((option) => option.querySelector('[type="checkbox"]')).length;
+	const textareaCount = options.filter(
+		(option) =>
+			option instanceof HTMLTextAreaElement ||
+			(option instanceof HTMLInputElement && option.type === 'text') ||
+			option.querySelector('textarea,input[type="text"]')
+	).length;
+
+	if (radioCount === 2) {
+		return 'judgement';
+	}
+	if (radioCount > 0) {
+		return 'single';
+	}
+	if (checkboxCount > 0) {
+		return 'multiple';
+	}
+	if (textareaCount > 0) {
+		return 'completion';
+	}
+}
+
+function fillInputValue(element: HTMLElement, answer: string) {
+	const input =
+		element instanceof HTMLInputElement
+			? element
+			: element instanceof HTMLTextAreaElement
+			? element
+			: element.querySelector<HTMLInputElement | HTMLTextAreaElement>('input[type="text"], textarea');
+
+	if (!input) {
+		return;
+	}
+
+	input.value = answer;
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+	input.dispatchEvent(new Event('change', { bubbles: true }));
+	(input as HTMLElement).focus?.();
+	(input as HTMLElement).blur?.();
+}
+
+function clickChoiceOption(option: HTMLElement) {
+	const input = option.querySelector<HTMLInputElement>('input[type="radio"], input[type="checkbox"]');
+	if (input?.checked) {
+		return;
+	}
+
+	option.click();
+	input?.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+export function yktExamWork({ answererWrappers, period, thread, answerSeparators, answerMatchMode }: CommonWorkOptions) {
+	$message.info({ content: '开始作业/考试' });
+	CommonProject.scripts.workResults.methods.init();
+
+	const titleTransform = (titles: (HTMLElement | undefined)[]) => getQuestionTitle(titles);
+
+	const worker = new OCSWorker({
+		root: '.exercise-item',
+		elements: {
+			title: '.item-body h4.exam-font',
+			options: '.item-body .el-radio, .item-body .el-checkbox, .item-body textarea, .item-body input[type="text"]'
+		},
+		thread: thread ?? 1,
+		answerSeparators: answerSeparators.split(',').map((s) => s.trim()),
+		answerMatchMode: answerMatchMode,
+		answerer: (elements, ctx) => {
+			const title = titleTransform(elements.title);
+
+			if (!title) {
+				throw new Error('题目为空，请忽略此题或反馈页面结构变化。');
+			}
+
+			return CommonProject.scripts.apps.methods.searchAnswerInCaches(title, async () => {
+				await $.sleep((period ?? 3) * 1000);
+				return defaultAnswerWrapperHandler(answererWrappers, {
+					type: ctx.type || 'unknown',
+					title,
+					options: getQuestionOptions((ctx.elements.options || []) as HTMLElement[])
+				});
+			});
+		},
+		work: {
+			type(ctx) {
+				return inferQuestionType(ctx.root, (ctx.elements.options || []) as HTMLElement[]);
+			},
+			async handler(type, answer, option) {
+				if (type === 'single' || type === 'multiple' || type === 'judgement') {
+					clickChoiceOption(option);
+					return;
+				}
+
+				if (type === 'completion' && answer.trim()) {
+					fillInputValue(option, answer.trim());
+				}
+			}
+		},
+		onResultsUpdate(curr, _, res) {
+			const simplified = simplifyWorkResult(res, titleTransform);
+			CommonProject.scripts.workResults.methods.setResults(simplified);
+
+			if (curr.result?.finish) {
+				CommonProject.scripts.apps.methods.addQuestionCacheFromWorkResult(
+					simplifyWorkResult([curr as WorkResult<any>], titleTransform)
+				);
+			}
+
+			CommonProject.scripts.workResults.methods.updateWorkStateByResults(res);
+		}
+	});
+
+	worker
+		.doWork({ enable_debug: BackgroundProject.scripts.dev.cfg.enable_answerer_debug })
+		.then(() => {
+			$message.info({ content: '作业/考试完成，请自行检查后提交。', duration: 0 });
+			worker.emit('done');
+		})
+		.catch((err) => {
+			$message.error({ content: `作业/考试失败: ${err}`, duration: 0 });
+		});
+
+	return worker;
+}

--- a/packages/scripts/src/projects/yuketang.ts
+++ b/packages/scripts/src/projects/yuketang.ts
@@ -1,9 +1,11 @@
-import { $, $elements, Project, Script, $message, $modal, $el } from 'easy-us';
+import { $, $elements, Project, Script, $message, $modal, $el, $ui } from 'easy-us';
 import { $msg, playMedia } from '../utils';
 import { request } from '@ocsjs/core';
 import { restudy, volume } from '../utils/configs';
 import { waitForElement } from '../utils/study';
 import { CommonProject } from './common';
+import { commonWork } from '../utils/work';
+import { yktExamWork } from './yuketang.exam';
 
 const state = {
 	study: {
@@ -13,7 +15,7 @@ const state = {
 
 export const YKTProject = Project.create({
 	name: '雨课堂',
-	domains: ['yuketang.cn'],
+	domains: ['yuketang.cn', 'xuetangx.com'],
 	scripts: {
 		guide: new Script({
 			name: '🖥️ 使用提示',
@@ -153,6 +155,27 @@ export const YKTProject = Project.create({
 				};
 
 				study();
+			}
+		}),
+		work: new Script({
+			name: '✍️ 作业/考试脚本',
+			matches: [['考试页面', 'examination.xuetangx.com/exam']],
+			namespace: 'yuketang.work',
+			configs: {
+				notes: {
+					defaultValue: $ui.notes([
+						'自动答题前请在 “通用-全局设置” 中设置题库配置。',
+						'可以搭配 “通用-在线搜题” 一起使用。',
+						'请手动进入作业考试页面才能使用自动答题。',
+						'自动答题时请勿切换题目，否则可能导致重复搜题或者脚本卡主。'
+					]).outerHTML
+				}
+			},
+			oncomplete() {
+				$message.warn({ content: '自动答题时请勿切换题目，否则可能导致重复搜题或者脚本卡主。', duration: 0 });
+				commonWork(this, {
+					workerProvider: yktExamWork
+				});
 			}
 		}),
 		// TODO 作业


### PR DESCRIPTION
## What changed
- add YukeTang exam auto-answer support for `examination.xuetangx.com/exam`
- register a new YukeTang exam script under the existing YukeTang project
- reuse the existing OCS answer workflow, question cache, and work result panel

## Why
Rain Classroom study flow was already supported, but the exam page had no question-bank auto-answer integration.

## Impact
Users can now run the standard OCS answer workflow on the supported YukeTang exam layout without changing their existing global answerer settings.

## Validation
- `pnpm exec tsc -p packages/utils/tsconfig.json`
- `pnpm exec tsc -p packages/core/tsconfig.json`
- `pnpm exec tsc -p packages/scripts/tsconfig.json`
- `VITE_BUILD_PATH=../../dist pnpm build`

## Notes
- verified locally against the provided `examination.xuetangx.com` page capture
- auto-submit is intentionally not included in this first pass
- manual test confirmed by the requester
