### PR TITLE
fix: 将 scripts 包纳入类型检查

### DIFF
--- a/scripts/tsc.js
+++ b/scripts/tsc.js
@@ -4,6 +4,7 @@ const { execOut } = require('./utils');
 exports.default = series(
 	series(
 		() => execOut('tsc', { cwd: '../packages/utils' }),
-		() => execOut('tsc', { cwd: '../packages/core' })
+		() => execOut('tsc', { cwd: '../packages/core' }),
+		() => execOut('tsc', { cwd: '../packages/scripts' })
 	)
 );


### PR DESCRIPTION
## 变更说明

- 在 scripts/tsc.js 中新增 packages/scripts 的 	sc 检查
- 保持检查顺序为 utils -> core -> scripts，确保 scripts 包检查前已生成 core 类型声明

## 验证

- corepack pnpm exec gulp -f ./scripts/tsc.js

Fixes #305