### PR TITLE
fix(script): 修复 waitForMedia 中 setInterval 内存泄漏

### DIFF
--- a/packages/scripts/src/utils/study.ts
+++ b/packages/scripts/src/utils/study.ts
@@ -19,25 +19,30 @@ export async function waitForMedia(options?: {
 	timeout?: number;
 	filter?: (video: HTMLVideoElement | HTMLAudioElement) => boolean;
 }) {
-	const res = await Promise.race([
-		new Promise<HTMLVideoElement | HTMLAudioElement>((resolve, reject) => {
-			const interval = setInterval(() => {
-				const video = (options?.root || document).querySelector<HTMLVideoElement | HTMLAudioElement>(
-					`${options?.videoSelector || 'video'},${options?.audioSelector || 'audio'}`
-				);
-				if (video && (!options?.filter || options.filter(video))) {
-					clearInterval(interval);
-					resolve(video);
+	const timeoutMs = options?.timeout ?? 3 * 60 * 1000;
+
+	const res = await new Promise<HTMLVideoElement | HTMLAudioElement>((resolve, reject) => {
+		let timeoutId: ReturnType<typeof setTimeout> | undefined;
+		const interval = setInterval(() => {
+			const video = (options?.root || document).querySelector<HTMLVideoElement | HTMLAudioElement>(
+				`${options?.videoSelector || 'video'},${options?.audioSelector || 'audio'}`
+			);
+			if (video && (!options?.filter || options.filter(video))) {
+				clearInterval(interval);
+				if (timeoutId !== undefined) {
+					clearTimeout(timeoutId);
 				}
-			}, 200);
-		}),
-		$.sleep(options?.timeout ?? 3 * 60 * 1000)
-	]);
-	if (res) {
-		return res;
-	} else {
-		throw new Error('视频/音频未找到，或者加载超时。');
-	}
+				resolve(video);
+			}
+		}, 200);
+
+		timeoutId = setTimeout(() => {
+			clearInterval(interval);
+			reject(new Error('视频/音频未找到，或者加载超时。'));
+		}, timeoutMs);
+	});
+
+	return res;
 }
 
 export function waitForElement(


### PR DESCRIPTION
### 问题

`waitForMedia` 函数使用 `Promise.race` 竞争轮询定时器和超时定时器。当超时先触发时，轮询的 `setInterval` 永远不会被清除，导致：
1.内存泄漏：每200ms重复查找dom
2.长时间运行内存持续增长

### 修复方案

移除 `Promise.race` 模式，将轮询和超时逻辑合并到单个 Promise 中，然后分两种情况。找到视频时，清除 `interval` 和 `timeout`，正常 resolve；超时时，清除 `interval`，reject 抛出错误。可以确保无论哪条路径被触发，`setInterval` 都会被正确清理。