### PR TITLE
fix(core): 优化单选题匹配算法，优先选择精确匹配项

### DIFF
--- a/packages/core/src/core/utils/string.ts
+++ b/packages/core/src/core/utils/string.ts
@@ -38,8 +38,22 @@ export function answerNormalizedMatch(answers: string[], options: string[]): str
 
 	return _answers.length !== 0
 		? _options
-				.map((opt, i) => ({ opt, original: options[i] }))
-				.filter(({ opt }) => _answers.some((ans) => ans === opt || opt.includes(ans) || ans.includes(opt)))
+				.map((opt, i) => {
+					let level = 0;
+					if (opt) {
+						for (const ans of _answers) {
+							if (ans === opt) {
+								level = 2;
+								break;
+							} else if (opt.includes(ans) || ans.includes(opt)) {
+								level = 1;
+							}
+						}
+					}
+					return { opt, original: options[i], level };
+				})
+				.filter(({ level }) => level > 0)
+				.sort((a, b) => b.level - a.level)
 				.map(({ original }) => original)
 		: [];
 }

--- a/tests/cases.json
+++ b/tests/cases.json
@@ -11,6 +11,16 @@
       "expect": "计算机网络"
     },
     {
+      "a": "16M",
+      "opts": [
+        "16MB",
+        "16M",
+        "32M",
+        "32MB"
+      ],
+      "expect": "16M"
+    },
+    {
       "a": "hello world",
       "opts": [
         "hello, world!",


### PR DESCRIPTION
在之前的逻辑中，由于 answerNormalizedMatch 只做包含检查而没有区分匹配优先级，当选项中包含干扰项且排在精确匹配项之前时，会被错误地选中。
例如
选项A:16MB
选项B:16M
答案为16M
则会自动匹配到A,而非B

该提交引入了优先级排序，确保完全相等的选项（优先级2）优先于包含选项（优先级1）。同时补充了相关的测试用例。